### PR TITLE
Add replace colons support for zwj joined emojis with skintones

### DIFF
--- a/emoji_data_python/replacement.py
+++ b/emoji_data_python/replacement.py
@@ -1,4 +1,5 @@
 import re
+from typing import cast
 
 
 def replace_colons(text: str, strip: bool = False) -> str:
@@ -19,7 +20,7 @@ def replace_colons(text: str, strip: bool = False) -> str:
 
         if matchobj.lastindex == 2:
             skin_tone_match = matchobj.group(2)
-            skin_tone: EmojiChar = emoji_short_names.get(skin_tone_match.strip(':'))
+            skin_tone = cast(EmojiChar, emoji_short_names.get(skin_tone_match.strip(':')))
 
             if base_emoji is None:
                 return f'{emoji_match if strip is False else ""}{skin_tone.char}'

--- a/emoji_data_python/replacement.py
+++ b/emoji_data_python/replacement.py
@@ -1,5 +1,4 @@
 import re
-from typing import cast
 
 
 def replace_colons(text: str, strip: bool = False) -> str:
@@ -20,7 +19,7 @@ def replace_colons(text: str, strip: bool = False) -> str:
 
         if matchobj.lastindex == 2:
             skin_tone_match = matchobj.group(2)
-            skin_tone = cast(EmojiChar, emoji_short_names.get(skin_tone_match.strip(':')))
+            skin_tone: EmojiChar = emoji_short_names.get(skin_tone_match.strip(':'))
 
             if base_emoji is None:
                 return f'{emoji_match if strip is False else ""}{skin_tone.char}'
@@ -29,10 +28,10 @@ def replace_colons(text: str, strip: bool = False) -> str:
             if emoji_with_skin_tone is None:
                 return f'{base_emoji.char}{skin_tone.char}'
             return emoji_with_skin_tone.char
-        else:
-            if base_emoji is None:
-                return f'{emoji_match if strip is False else ""}'
-            return base_emoji.char
+
+        if base_emoji is None:
+            return f'{emoji_match if strip is False else ""}'
+        return base_emoji.char
 
     return re.sub(r'(\:[a-zA-Z0-9-_+]+\:)(\:skin-tone-[2-6]\:)?', emoji_repl, text)
 

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -12,6 +12,7 @@ class EmojiConversionTestCase(unittest.TestCase):
 
     def test_multiple_unified_to_char(self):
         self.assertEqual('👨‍🌾', unified_to_char('1F468-200D-1F33E'))
+        self.assertEqual('👩🏼‍🌾', unified_to_char('1F469-1F3FC-200D-1F33E'))
         self.assertEqual('🇳🇬', unified_to_char('1F1F3-1F1EC'))
         self.assertEqual('\U0001F1F3\U0001F1EC', unified_to_char('1F1F3-1F1EC'))
         self.assertEqual('4⃣', unified_to_char('0034-20E3'))
@@ -24,6 +25,7 @@ class EmojiConversionTestCase(unittest.TestCase):
         self.assertEqual('1F1E6', char_to_unified('\U0001F1E6'))
 
     def test_multiple_char_to_unified(self):
+        self.assertEqual('1F469-1F3FC-200D-1F33E', char_to_unified('👩🏼‍🌾'))
         self.assertEqual('1F468-200D-1F33E', char_to_unified('👨‍🌾'))
         self.assertEqual('1F1F3-1F1EC', char_to_unified('🇳🇬'))
         self.assertEqual('1F1F3-1F1EC', char_to_unified('\U0001F1F3\U0001F1EC'))

--- a/tests/test_replacement.py
+++ b/tests/test_replacement.py
@@ -24,6 +24,10 @@ class ReplaceColonsTestCase(unittest.TestCase):
         self.assertEqual('👨‍👩‍👦', replace_colons(':man-woman-boy:'))
         self.assertEqual('👨‍🌾', replace_colons(':male-farmer:'))
 
+    def test_zwj_emoji_skin_tone(self):
+        """This tests zwj emojis that also have a skin tone"""
+        self.assertEqual('👨🏼‍🌾', replace_colons(':male-farmer::skin-tone-3:'))
+
     def test_unknown_code(self):
         self.assertEqual('💩💩 :poo:🏼', replace_colons(':hankey::poop: :poo::skin-tone-3:'))
 

--- a/tests/test_replacement.py
+++ b/tests/test_replacement.py
@@ -11,6 +11,9 @@ class ReplaceColonsTestCase(unittest.TestCase):
     def test_skin_tone(self):
         self.assertEqual('👋🏼', replace_colons(':wave::skin-tone-3:'))
 
+    def test_skin_tone_appended_to_emoji_with_no_skin_tone(self):
+        self.assertEqual('💩🏼', replace_colons(':poop::skin-tone-3:'))
+
     def test_underscore_hyphenated_codes(self):
         self.assertEqual('😙', replace_colons(':kissing_smiling_eyes:'))
         self.assertEqual('😘', replace_colons(':kissing-heart:'))
@@ -30,9 +33,11 @@ class ReplaceColonsTestCase(unittest.TestCase):
 
     def test_unknown_code(self):
         self.assertEqual('💩💩 :poo:🏼', replace_colons(':hankey::poop: :poo::skin-tone-3:'))
+        self.assertEqual('💩:poo: 🐶 :poo:', replace_colons(':poop::poo: :dog: :poo:'))
 
     def test_strip_unknown_code(self):
         self.assertEqual('💩💩 🏼', replace_colons(':hankey::poop: :poo::skin-tone-3:', strip=True))
+        self.assertEqual('💩 🐶 ', replace_colons(':poop::poo: :dog: :poo:', strip=True))
 
     def test_multiline_sentence(self):
         self.assertEqual("""


### PR DESCRIPTION
Zero-width-joined emojis with skin-tones such as 👩🏾‍🌾 aren't handled properly by `replace_colons` currently. I've added tests to demonstrate, and an update to the function itself to handle this.

Apologies for the added complexity to the function - the only way I could maintain backwards compatibility with the current implementation & the `strip` argument.

![image](https://user-images.githubusercontent.com/7358629/75644640-10ce6400-5c97-11ea-9edb-3e948c7d7eff.png)
